### PR TITLE
Refactor lint() so it isn't using global state

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,18 +2,16 @@
 'use strict';
 
 const commander = require('commander');
+const _ = require('lodash');
 
 const pkg = require('./package.json');
-const linters = require('./index').linters;
+const registeredLinters = require('./index').linters;
 const Reporter = require('./reporter');
-
-const keys = Object.keys(linters);
-const reporter = new Reporter();
 
 commander
   .version(pkg.version)
   .arguments('<path>')
-  .action(path => lint(path))
+  .action(path => lint(path, _.values(registeredLinters)))
   .usage('[options] <path>')
   .parse(process.argv);
 
@@ -21,14 +19,17 @@ if (!process.argv.slice(2).length) {
   commander.outputHelp();
 }
 
-function lint(path) {
-  const key = keys.pop();
-  if (key) {
-    const linter = new linters[key](path);
-    linter.run(reporter)
-      .then(() => {lint(path)});
+function lint(path, linters, reporter = new Reporter()) {
+  const Linter = linters[0];
+
+  if (Linter) {
+    const linter = new Linter(path);
+    linter.run(reporter).then(() => {
+      lint(path, linters.slice(1), reporter);
+    });
   } else {
     reporter.finalize();
+
     if (reporter.failures.length > 0) {
       process.on('exit', () => process.exit(1));
     }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 'use strict';
 
 module.exports.linters = {


### PR DESCRIPTION
The `lint()` function `cli.js` relied on calling `.pop()` on `keys` which was outside its scope 😱. 

I've cleaned it up to asynchronously recurse over itself, passing the remaining linters as an argument without mutating the list.