### PR TITLE
Remove formatting inside of the linter

### DIFF
--- a/linters/i18n.js
+++ b/linters/i18n.js
@@ -73,23 +73,20 @@ module.exports = class I18nLinter {
         if (key === defaultLocale) return;
 
         const localeKeys = Object.keys(localeData);
-
-        const errors = [];
+        const localePath = this.localePath(key);
 
         const missingKeys = _.difference(defaultLocaleKeys, localeKeys);
         if (missingKeys.length > 0) {
-          errors.push(`missing: ${missingKeys.map(k => `'${k}'`).join(', ')}`);
+          reporter.failure(`Missing entries found: ${missingKeys.map(k => `'${k}'`).join(', ')}`, localePath);
         }
 
         const extraKeys = _.difference(localeKeys, defaultLocaleKeys);
         if (extraKeys.length > 0) {
-          errors.push(`extra: ${extraKeys.map(k => `'${k}'`).join(', ')}`);
+          reporter.failure(`Extra entries found: ${extraKeys.map(k => `'${k}'`).join(', ')}`, localePath);
         }
 
-        if (errors.length === 0) {
-          reporter.success(`'${key}' has all the entries present in '${defaultLocale}'`, this.localePath(key));
-        } else {
-          reporter.failure(`Mismatching entries found ${errors}`, this.localePath(key));
+        if (missingKeys.length == 0 && extraKeys.length == 0) {
+          reporter.success(`'${key}' has all the entries present in '${defaultLocale}'`, localePath);
         }
       });
     });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "mocha": "^3.0.2",
-    "mock-fs": "^3.11.0"
+    "mock-fs": "^4.3.0"
   },
   "directories": {
     "test": "test"

--- a/test/linters/i18n_test.js
+++ b/test/linters/i18n_test.js
@@ -150,7 +150,7 @@ describe('I18nLinter', function(){
         assert.equal(1, this.reporter.failures.length);
         const [message, file] = this.reporter.failures[0];
         assert.equal('/path/to/theme/locales/fr.json', file);
-        assert.equal("Mismatching entries found missing: 'hello', 'bye'", message);
+        assert.equal("Missing entries found: 'hello', 'bye'", message);
       });
     });
 
@@ -166,7 +166,7 @@ describe('I18nLinter', function(){
         assert.equal(1, this.reporter.failures.length);
         const [message, file] = this.reporter.failures[0];
         assert.equal('/path/to/theme/locales/fr.json', file);
-        assert.equal("Mismatching entries found extra: 'hello', 'bye'", message);
+        assert.equal("Extra entries found: 'hello', 'bye'", message);
       });
     });
 


### PR DESCRIPTION
There is currently formatted strings contained inside of the linter. Let's remove this so we have more control over this with the reporter class. We end up with output like this:

![image](https://cloud.githubusercontent.com/assets/991693/25668074/937f685a-2ff3-11e7-8296-b6e4fb8d39f5.png)