### PR TITLE
Export a runAll() function for convenience

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,13 +5,12 @@ const commander = require('commander');
 const _ = require('lodash');
 
 const pkg = require('./package.json');
-const registeredLinters = require('./index').linters;
-const Reporter = require('./reporter');
+const {runAll} = require('./index');
 
 commander
   .version(pkg.version)
   .arguments('<path>')
-  .action(path => lint(path, _.values(registeredLinters)))
+  .action(path => lint(path))
   .usage('[options] <path>')
   .parse(process.argv);
 
@@ -19,19 +18,15 @@ if (!process.argv.slice(2).length) {
   commander.outputHelp();
 }
 
-function lint(path, linters, reporter = new Reporter()) {
-  const Linter = linters[0];
-
-  if (Linter) {
-    const linter = new Linter(path);
-    linter.run(reporter).then(() => {
-      lint(path, linters.slice(1), reporter);
-    });
-  } else {
+function lint(path) {
+  return runAll(path).then(reporter => {
     reporter.finalize();
 
     if (reporter.failures.length > 0) {
       process.on('exit', () => process.exit(1));
     }
-  }
+  }).catch(e => {
+    console.log(e);
+    process.on('exit', () => process.exit(1));
+  });
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,18 @@
 'use strict';
 
-module.exports.linters = {
+const _ = require('lodash');
+
+const Reporter = require('./reporter');
+const linters = {
   i18n: require('./linters/i18n')
+};
+
+module.exports.linters = linters;
+
+module.exports.runAll = function(path, reporter = new Reporter()) {
+  return _.values(linters)
+    .reduce((chain, Linter) => {
+      return chain.then(() => (new Linter(path)).run(reporter))
+    }, Promise.resolve())
+    .then(() => reporter);
 };


### PR DESCRIPTION
Adds a `runAll(path, reporter = new Reporter())` function that runs all the registered linters in sequence and returns the reporter.

This should make https://github.com/Shopify/slate-tools/pull/55/files#r114844049 a bit easier.