### PR TITLE
Using standardJS for linting and removing unused dependency on cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,32 +1,31 @@
 #!/usr/bin/env node
-'use strict';
+'use strict'
 
-const commander = require('commander');
-const _ = require('lodash');
+const commander = require('commander')
 
-const pkg = require('./package.json');
-const {runAll} = require('./index');
+const pkg = require('./package.json')
+const {runAll} = require('./index')
 
 commander
   .version(pkg.version)
   .arguments('<path>')
   .action(path => lint(path))
   .usage('[options] <path>')
-  .parse(process.argv);
+  .parse(process.argv)
 
 if (!process.argv.slice(2).length) {
-  commander.outputHelp();
+  commander.outputHelp()
 }
 
-function lint(path) {
+function lint (path) {
   return runAll(path).then(reporter => {
-    reporter.finalize();
+    reporter.finalize()
 
     if (reporter.failures.length > 0) {
-      process.on('exit', () => process.exit(1));
+      process.on('exit', () => process.exit(1))
     }
   }).catch(e => {
-    console.log(e);
-    process.on('exit', () => process.exit(1));
-  });
+    console.log(e)
+    process.on('exit', () => process.exit(1))
+  })
 }

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
-'use strict';
+'use strict'
 
-const _ = require('lodash');
+const _ = require('lodash')
 
-const Reporter = require('./reporter');
+const Reporter = require('./reporter')
 const linters = {
   i18n: require('./linters/i18n')
-};
+}
 
-module.exports.linters = linters;
+module.exports.linters = linters
 
-module.exports.runAll = function(path, reporter = new Reporter()) {
+module.exports.runAll = function (path, reporter = new Reporter()) {
   return _.values(linters)
     .reduce((chain, Linter) => {
       return chain.then(() => (new Linter(path)).run(reporter))
     }, Promise.resolve())
-    .then(() => reporter);
-};
+    .then(() => reporter)
+}

--- a/linters/i18n.js
+++ b/linters/i18n.js
@@ -1,228 +1,228 @@
-'use strict';
+'use strict'
 
-const _ = require('lodash');
-const fs = require('fs');
-const glob = require('glob');
-const path = require('path');
-const htmllint = require('htmllint');
+const _ = require('lodash')
+const fs = require('fs')
+const glob = require('glob')
+const path = require('path')
+const htmllint = require('htmllint')
 
-const Reporter = require('../reporter');
+const Reporter = require('../reporter')
 
-const PIPE_T_RXP = /\{\{\s*('|")((?:(?!\1).)+)\1\s*\|\s*t(?:ranslate)?(?::(.*?)\s*(?:\||\}\}))?/g;
+const PIPE_T_RXP = /\{\{\s*('|")((?:(?!\1).)+)\1\s*\|\s*t(?:ranslate)?(?::(.*?)\s*(?:\||\}\}))?/g
 
-const PLURALIZATION_KEYS = ['zero', 'one', 'two', 'other'];
+const PLURALIZATION_KEYS = ['zero', 'one', 'two', 'other']
 
 // https://github.com/htmllint/htmllint/wiki/Options
 const HTML_LINT_RULES = {
   'line-end-style': false,
   'id-class-style': false
-};
+}
 
 module.exports = class I18nLinter {
-  constructor(targetDirectory) {
-    this.targetDirectory = targetDirectory;
+  constructor (targetDirectory) {
+    this.targetDirectory = targetDirectory
 
-    this.loadTranslations = _.memoize(this.loadTranslations);
-    this.listAllReferences = _.memoize(this.listAllReferences);
+    this.loadTranslations = _.memoize(this.loadTranslations)
+    this.listAllReferences = _.memoize(this.listAllReferences)
   }
 
-  run(reporter = new Reporter) {
+  run (reporter = new Reporter()) {
     return this.testDefaultLocale(reporter)
       .then(() => this.testReferencedKeys(reporter))
       .then(() => this.testMismatchedKeys(reporter))
-      .then(() => this.testHTML(reporter));
+      .then(() => this.testHTML(reporter))
   }
 
-  testDefaultLocale(reporter) {
+  testDefaultLocale (reporter) {
     return this.defaultLocale().then(defaultLocale => {
       if (defaultLocale) {
-        reporter.success('Includes a default locale file', this.localePath(defaultLocale));
+        reporter.success('Includes a default locale file', this.localePath(defaultLocale))
       } else {
-        reporter.failure('Does not include a default locale file');
+        reporter.failure('Does not include a default locale file')
       }
-    });
+    })
   }
 
-  testReferencedKeys(reporter) {
+  testReferencedKeys (reporter) {
     return Promise.all([
       this.loadTranslations(),
       this.defaultLocale(),
       this.listAllReferences()
     ]).then(([translations, defaultLocale, referencedKeys]) => {
-      const defaultLocaleData = translations[defaultLocale] || {};
+      const defaultLocaleData = translations[defaultLocale] || {}
 
       referencedKeys.forEach(({file, index, key}) => {
         if (defaultLocaleData[key]) {
-          reporter.success(`'${key}' has a matching entry in '${defaultLocale}'`, file, index);
+          reporter.success(`'${key}' has a matching entry in '${defaultLocale}'`, file, index)
         } else {
-          reporter.failure(`'${key}' does not have a matching entry in '${defaultLocale}'`, file, index);
+          reporter.failure(`'${key}' does not have a matching entry in '${defaultLocale}'`, file, index)
         }
-      });
-    });
+      })
+    })
   }
 
-  testMismatchedKeys(reporter) {
+  testMismatchedKeys (reporter) {
     return Promise.all([
       this.loadTranslations(),
       this.defaultLocale()
     ]).then(([translations, defaultLocale]) => {
-      const defaultLocaleData = translations[defaultLocale] || {};
-      const defaultLocaleKeys = Object.keys(defaultLocaleData);
+      const defaultLocaleData = translations[defaultLocale] || {}
+      const defaultLocaleKeys = Object.keys(defaultLocaleData)
 
       _.forOwn(translations, (localeData, key) => {
-        if (key === defaultLocale) return;
+        if (key === defaultLocale) return
 
-        const localeKeys = Object.keys(localeData);
-        const localePath = this.localePath(key);
+        const localeKeys = Object.keys(localeData)
+        const localePath = this.localePath(key)
 
-        const missingKeys = _.difference(defaultLocaleKeys, localeKeys);
+        const missingKeys = _.difference(defaultLocaleKeys, localeKeys)
         if (missingKeys.length > 0) {
-          reporter.failure(`Missing entries found: ${missingKeys.map(k => `'${k}'`).join(', ')}`, localePath);
+          reporter.failure(`Missing entries found: ${missingKeys.map(k => `'${k}'`).join(', ')}`, localePath)
         }
 
-        const extraKeys = _.difference(localeKeys, defaultLocaleKeys);
+        const extraKeys = _.difference(localeKeys, defaultLocaleKeys)
         if (extraKeys.length > 0) {
-          reporter.failure(`Extra entries found: ${extraKeys.map(k => `'${k}'`).join(', ')}`, localePath);
+          reporter.failure(`Extra entries found: ${extraKeys.map(k => `'${k}'`).join(', ')}`, localePath)
         }
 
         if (missingKeys.length == 0 && extraKeys.length == 0) {
-          reporter.success(`'${key}' has all the entries present in '${defaultLocale}'`, localePath);
+          reporter.success(`'${key}' has all the entries present in '${defaultLocale}'`, localePath)
         }
-      });
-    });
+      })
+    })
   }
 
-  testHTML(reporter) {
+  testHTML (reporter) {
     return this.loadTranslations().then((translationsByLocale) => {
-      const promises = [];
+      const promises = []
 
       _.forOwn(translationsByLocale, (translations, locale) => {
         _.forOwn(translations, (value, key) => {
-          if (!this.isHTMLKey(key)) return;
+          if (!this.isHTMLKey(key)) return
 
           promises.push(
             htmllint(value, HTML_LINT_RULES).then((issues) => {
-              return { value, key, issues, locale };
+              return { value, key, issues, locale }
             })
-          );
-        });
-      });
+          )
+        })
+      })
 
       return Promise.all(promises).then((results) => {
         results.forEach((result) => {
           if (result.issues.length) {
             reporter.failure(
               `'${result.key}' contains invalid HTML. See ${this.lintRuleURL(result.issues[0].rule)}`,
-              this.localePath(result.locale));
+              this.localePath(result.locale))
           } else {
-            reporter.success(`'${result.key}' contains valid HTML`, this.localePath(result.locale));
+            reporter.success(`'${result.key}' contains valid HTML`, this.localePath(result.locale))
           }
-        });
-      });
-    });
+        })
+      })
+    })
   }
 
-  isHTMLKey(key) {
-    const keyParts = key.split('.');
-    let lastPart = _.last(keyParts);
+  isHTMLKey (key) {
+    const keyParts = key.split('.')
+    let lastPart = _.last(keyParts)
 
     if (_.includes(PLURALIZATION_KEYS, lastPart)) {
-      lastPart = keyParts.slice(-2, -1)[0];
+      lastPart = keyParts.slice(-2, -1)[0]
     }
 
-    return _.endsWith(lastPart, '_html');
+    return _.endsWith(lastPart, '_html')
   }
 
-  listLiquidFiles() {
+  listLiquidFiles () {
     return new Promise((resolve, reject) => {
       glob(path.join(this.targetDirectory, '**/*.liquid'), (err, files) => {
-        if (err) return reject(err);
-        resolve(files);
-      });
-    });
+        if (err) return reject(err)
+        resolve(files)
+      })
+    })
   }
 
-  listReferences(file) {
+  listReferences (file) {
     return new Promise((resolve, reject) => {
       fs.readFile(file, {encoding: 'utf-8'}, (err, content) => {
-        if (err) return reject(err);
+        if (err) return reject(err)
 
-        const matcher = new RegExp(PIPE_T_RXP);
-        const references = [];
+        const matcher = new RegExp(PIPE_T_RXP)
+        const references = []
 
         while (true) {
-          const match = matcher.exec(content);
-          if (!match) break;
+          const match = matcher.exec(content)
+          if (!match) break
 
-          const key = match[2];
-          const args = match[3];
+          const key = match[2]
+          const args = match[3]
 
-          const reference = {file, key, index: match.index};
+          const reference = {file, key, index: match.index}
 
           // https://help.shopify.com/themes/development/internationalizing/translation-filter#pluralization-in-translation-keys
           if (args && args.split(/\s+/).indexOf('count:') >= 0) {
-            reference.key += '.other';
+            reference.key += '.other'
           }
 
-          references.push(reference);
+          references.push(reference)
         }
 
-        resolve(references);
-      });
-    });
+        resolve(references)
+      })
+    })
   }
 
-  listAllReferences() {
+  listAllReferences () {
     return this.listLiquidFiles()
       .then(files => Promise.all(files.map(f => this.listReferences(f))))
-      .then(results => [].concat(...results));
+      .then(results => [].concat(...results))
   }
 
-  listTranslationFiles() {
+  listTranslationFiles () {
     return new Promise((resolve, reject) => {
       glob(path.join(this.targetDirectory, 'locales/*.json'), (err, files) => {
-        if (err) return reject(err);
-        resolve(files);
-      });
-    });
+        if (err) return reject(err)
+        resolve(files)
+      })
+    })
   }
 
-  flattenKeys(entry, keys = [], acc = {}) {
+  flattenKeys (entry, keys = [], acc = {}) {
     if (_.isObject(entry)) {
-      _.forOwn(entry, (value, key) => this.flattenKeys(value, keys.concat(key), acc));
+      _.forOwn(entry, (value, key) => this.flattenKeys(value, keys.concat(key), acc))
     } else {
-      acc[keys.join('.')] = entry;
+      acc[keys.join('.')] = entry
     }
-    return acc;
+    return acc
   }
 
-  loadTranslationFile(file) {
+  loadTranslationFile (file) {
     return new Promise((resolve, reject) => {
       fs.readFile(file, {encoding: 'utf-8'}, (err, content) => {
-        if (err) return reject(err);
-        const locale = path.basename(file, '.json');
-        resolve([locale, this.flattenKeys(JSON.parse(content))]);
-      });
-    });
+        if (err) return reject(err)
+        const locale = path.basename(file, '.json')
+        resolve([locale, this.flattenKeys(JSON.parse(content))])
+      })
+    })
   }
 
-  loadTranslations() {
+  loadTranslations () {
     return this.listTranslationFiles()
       .then(files => Promise.all(files.map(this.loadTranslationFile.bind(this))))
-      .then(_.fromPairs);
+      .then(_.fromPairs)
   }
 
-  defaultLocale() {
+  defaultLocale () {
     return this.loadTranslations().then(translations => {
-      return Object.keys(translations).find(k => k.includes('.default'));
-    });
+      return Object.keys(translations).find(k => k.includes('.default'))
+    })
   }
 
-  localePath(locale) {
-    return path.join(this.targetDirectory, 'locales', locale + '.json');
+  localePath (locale) {
+    return path.join(this.targetDirectory, 'locales', locale + '.json')
   }
 
-  lintRuleURL(rule) {
-    return `https://github.com/htmllint/htmllint/wiki/Options#${rule}`;
+  lintRuleURL (rule) {
+    return `https://github.com/htmllint/htmllint/wiki/Options#${rule}`
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "devDependencies": {
     "mocha": "^3.0.2",
-    "mock-fs": "^4.3.0"
+    "mock-fs": "^4.3.0",
+    "standard": "^10.0.2"
   },
   "directories": {
     "test": "test"

--- a/reporter.js
+++ b/reporter.js
@@ -1,47 +1,47 @@
-'use strict';
+'use strict'
 
-const chalk = require('chalk');
+const chalk = require('chalk')
 
 module.exports = class Reporter {
-  constructor(outputStream = require('process').stderr) {
-    this.outputStream = outputStream;
-    this.successes = [];
-    this.failures = [];
+  constructor (outputStream = require('process').stderr) {
+    this.outputStream = outputStream
+    this.successes = []
+    this.failures = []
   }
 
-  success(message, file = null, index = null) {
-    this.successes.push([message, file, index]);
-    this.outputStream.write(chalk.green('.'));
+  success (message, file = null, index = null) {
+    this.successes.push([message, file, index])
+    this.outputStream.write(chalk.green('.'))
   }
 
-  failure(message, file, index) {
-    this.failures.push([message, file, index]);
-    this.outputStream.write(chalk.red('.'));
+  failure (message, file, index) {
+    this.failures.push([message, file, index])
+    this.outputStream.write(chalk.red('.'))
   }
 
-  finalize() {
-    this.outputStream.write('\n\n');
+  finalize () {
+    this.outputStream.write('\n\n')
 
-    const testsRun = this.failures.length + this.successes.length;
+    const testsRun = this.failures.length + this.successes.length
 
     if (this.failures.length === 0) {
       this.outputStream.write([
         chalk.green('All good!'),
         `(${testsRun} checks run)`
-      ].join(' ') + '\n\n');
-      return;
+      ].join(' ') + '\n\n')
+      return
     }
 
     this.outputStream.write([
       chalk.red('Errors encountered!'),
       `(${testsRun} checks run)`
-    ].join(' ') + '\n\n');
+    ].join(' ') + '\n\n')
 
     this.failures.forEach(([message, file, index]) => {
       this.outputStream.write([
         chalk.red(`${file}${index ? ':' + index : ''}`),
         message
-      ].join('\n') + '\n\n');
-    });
+      ].join('\n') + '\n\n')
+    })
   }
-};
+}

--- a/test/linters/i18n_test.js
+++ b/test/linters/i18n_test.js
@@ -1,54 +1,54 @@
-'use strict';
+'use strict'
 
-const assert = require('assert');
-const mockFs = require('mock-fs');
-const {Writable} = require('stream');
+const assert = require('assert')
+const mockFs = require('mock-fs')
+const {Writable} = require('stream')
 
-const Reporter = require('../../reporter');
-const I18nLinter = require('../../linters/i18n');
+const Reporter = require('../../reporter')
+const I18nLinter = require('../../linters/i18n')
 
-describe('I18nLinter', function(){
-  beforeEach(function(){
-    const nullStream = new Writable;
-    nullStream._write = () => {};
+describe('I18nLinter', function () {
+  beforeEach(function () {
+    const nullStream = new Writable()
+    nullStream._write = () => {}
 
-    this.reporter = new Reporter(nullStream);
-    this.linter = new I18nLinter('/path/to/theme');
-  });
+    this.reporter = new Reporter(nullStream)
+    this.linter = new I18nLinter('/path/to/theme')
+  })
 
-  afterEach(function(){
-    mockFs.restore();
-  });
+  afterEach(function () {
+    mockFs.restore()
+  })
 
-  describe('#testDefaultLocale', function(){
-    it('reports a failure if the theme doesn\'t have a default locale', function(){
-      mockFs({'/path/to/theme': {}});
+  describe('#testDefaultLocale', function () {
+    it('reports a failure if the theme doesn\'t have a default locale', function () {
+      mockFs({'/path/to/theme': {}})
 
       return this.linter.testDefaultLocale(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message] = this.reporter.failures[0];
-        assert.equal('Does not include a default locale file', message);
-      });
-    });
+        assert.equal(1, this.reporter.failures.length)
+        const [message] = this.reporter.failures[0]
+        assert.equal('Does not include a default locale file', message)
+      })
+    })
 
-    it('reports a success if the theme has a default locale', function(){
+    it('reports a success if the theme has a default locale', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': '{}'
         }
-      }});
+      }})
 
       return this.linter.testDefaultLocale(this.reporter).then(() => {
-        assert.equal(1, this.reporter.successes.length);
-        const [message, file] = this.reporter.successes[0];
-        assert.equal('Includes a default locale file', message);
-        assert.equal('/path/to/theme/locales/en.default.json', file);
-      });
-    });
-  });
+        assert.equal(1, this.reporter.successes.length)
+        const [message, file] = this.reporter.successes[0]
+        assert.equal('Includes a default locale file', message)
+        assert.equal('/path/to/theme/locales/en.default.json', file)
+      })
+    })
+  })
 
-  describe('#testReferencedKeys', function(){
-    it('reports a failure for keys in liquid that are missing from the default locale', function(){
+  describe('#testReferencedKeys', function () {
+    it('reports a failure for keys in liquid that are missing from the default locale', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': '{}'
@@ -56,18 +56,18 @@ describe('I18nLinter', function(){
         'templates': {
           'product.liquid': '{{ "product.card.title" | t }}'
         }
-      }});
+      }})
 
       return this.linter.testReferencedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message, file, index] = this.reporter.failures[0];
-        assert.equal("'product.card.title' does not have a matching entry in 'en.default'", message);
-        assert.equal('/path/to/theme/templates/product.liquid', file);
-        assert.equal(0, index);
-      });
-    });
+        assert.equal(1, this.reporter.failures.length)
+        const [message, file, index] = this.reporter.failures[0]
+        assert.equal("'product.card.title' does not have a matching entry in 'en.default'", message)
+        assert.equal('/path/to/theme/templates/product.liquid', file)
+        assert.equal(0, index)
+      })
+    })
 
-    it('reports a failure for pluralized keys in liquid that are missing from the default locale', function(){
+    it('reports a failure for pluralized keys in liquid that are missing from the default locale', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': '{}'
@@ -75,18 +75,18 @@ describe('I18nLinter', function(){
         'templates': {
           'product.liquid': '{{ "product.inventory_with_count" | t: count: 1 }}'
         }
-      }});
+      }})
 
       return this.linter.testReferencedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message, file, index] = this.reporter.failures[0];
-        assert.equal("'product.inventory_with_count.other' does not have a matching entry in 'en.default'", message);
-        assert.equal('/path/to/theme/templates/product.liquid', file);
-        assert.equal(0, index);
-      });
-    });
+        assert.equal(1, this.reporter.failures.length)
+        const [message, file, index] = this.reporter.failures[0]
+        assert.equal("'product.inventory_with_count.other' does not have a matching entry in 'en.default'", message)
+        assert.equal('/path/to/theme/templates/product.liquid', file)
+        assert.equal(0, index)
+      })
+    })
 
-    it('reports a success for references that are present in the default locale', function(){
+    it('reports a success for references that are present in the default locale', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': JSON.stringify({
@@ -100,18 +100,18 @@ describe('I18nLinter', function(){
         'templates': {
           'product.liquid': '{{ "product.card.title" | t }}'
         }
-      }});
+      }})
 
       return this.linter.testReferencedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.successes.length);
-        const [message, file, index] = this.reporter.successes[0];
-        assert.equal("'product.card.title' has a matching entry in 'en.default'", message);
-        assert.equal('/path/to/theme/templates/product.liquid', file);
-        assert.equal(0, index);
-      });
-    });
+        assert.equal(1, this.reporter.successes.length)
+        const [message, file, index] = this.reporter.successes[0]
+        assert.equal("'product.card.title' has a matching entry in 'en.default'", message)
+        assert.equal('/path/to/theme/templates/product.liquid', file)
+        assert.equal(0, index)
+      })
+    })
 
-    it('reports a success for pluralized references that are present in the default locale', function(){
+    it('reports a success for pluralized references that are present in the default locale', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': JSON.stringify({
@@ -125,69 +125,69 @@ describe('I18nLinter', function(){
         'templates': {
           'product.liquid': '{{ "product.inventory_with_count" | t: count: 1 }}'
         }
-      }});
+      }})
 
       return this.linter.testReferencedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.successes.length);
-        const [message, file, index] = this.reporter.successes[0];
-        assert.equal("'product.inventory_with_count.other' has a matching entry in 'en.default'", message);
-        assert.equal('/path/to/theme/templates/product.liquid', file);
-        assert.equal(0, index);
-      });
-    });
-  });
+        assert.equal(1, this.reporter.successes.length)
+        const [message, file, index] = this.reporter.successes[0]
+        assert.equal("'product.inventory_with_count.other' has a matching entry in 'en.default'", message)
+        assert.equal('/path/to/theme/templates/product.liquid', file)
+        assert.equal(0, index)
+      })
+    })
+  })
 
-  describe('#testMismatchedKeys', function(){
-    it('reports a failure for keys present in the default locale but not others', function(){
+  describe('#testMismatchedKeys', function () {
+    it('reports a failure for keys present in the default locale but not others', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': JSON.stringify({'hello': 'Hello!', 'bye': 'Bye!'}),
           'fr.json': '{}'
         }
-      }});
+      }})
 
       return this.linter.testMismatchedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message, file] = this.reporter.failures[0];
-        assert.equal('/path/to/theme/locales/fr.json', file);
-        assert.equal("Missing entries found: 'hello', 'bye'", message);
-      });
-    });
+        assert.equal(1, this.reporter.failures.length)
+        const [message, file] = this.reporter.failures[0]
+        assert.equal('/path/to/theme/locales/fr.json', file)
+        assert.equal("Missing entries found: 'hello', 'bye'", message)
+      })
+    })
 
-    it('reports a failure for keys not present in the default locale but present in others', function(){
+    it('reports a failure for keys not present in the default locale but present in others', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': '{}',
           'fr.json': JSON.stringify({'hello': 'Bonjour!', 'bye': 'Au revoir!'})
         }
-      }});
+      }})
 
       return this.linter.testMismatchedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message, file] = this.reporter.failures[0];
-        assert.equal('/path/to/theme/locales/fr.json', file);
-        assert.equal("Extra entries found: 'hello', 'bye'", message);
-      });
-    });
+        assert.equal(1, this.reporter.failures.length)
+        const [message, file] = this.reporter.failures[0]
+        assert.equal('/path/to/theme/locales/fr.json', file)
+        assert.equal("Extra entries found: 'hello', 'bye'", message)
+      })
+    })
 
-    it('reports a success if all keys match', function(){
+    it('reports a success if all keys match', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': JSON.stringify({'hello': 'Hello!', 'bye': 'Bye!'}),
           'fr.json': JSON.stringify({'hello': 'Bonjour!', 'bye': 'Au revoir!'})
         }
-      }});
+      }})
 
       return this.linter.testMismatchedKeys(this.reporter).then(() => {
-        assert.equal(1, this.reporter.successes.length);
-        const [message, file] = this.reporter.successes[0];
-        assert.equal('/path/to/theme/locales/fr.json', file);
-        assert.equal("'fr' has all the entries present in 'en.default'", message);
-      });
-    });
-  });
+        assert.equal(1, this.reporter.successes.length)
+        const [message, file] = this.reporter.successes[0]
+        assert.equal('/path/to/theme/locales/fr.json', file)
+        assert.equal("'fr' has all the entries present in 'en.default'", message)
+      })
+    })
+  })
 
-  describe('#testHTML', function() {
+  describe('#testHTML', function () {
     it('reports a success for valid HTML', function () {
       mockFs({
         '/path/to/theme': {
@@ -195,32 +195,32 @@ describe('I18nLinter', function(){
             'en.default.json': JSON.stringify({ 'hello_html': '<h1>Hello!</h1>' })
           }
         }
-      });
+      })
 
       return this.linter.testHTML(this.reporter).then(() => {
-        assert.equal(1, this.reporter.successes.length);
-        const [message, file] = this.reporter.successes[0];
-        assert.equal('/path/to/theme/locales/en.default.json', file);
-        assert.equal("'hello_html' contains valid HTML", message);
-      });
-    });
+        assert.equal(1, this.reporter.successes.length)
+        const [message, file] = this.reporter.successes[0]
+        assert.equal('/path/to/theme/locales/en.default.json', file)
+        assert.equal("'hello_html' contains valid HTML", message)
+      })
+    })
 
-    it('reports a failure for invalid HTML', function() {
+    it('reports a failure for invalid HTML', function () {
       mockFs({'/path/to/theme': {
         'locales': {
           'en.default.json': JSON.stringify({ 'hello_html': '<h1>Hello!' })
         }
-      }});
+      }})
 
       return this.linter.testHTML(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message, file] = this.reporter.failures[0];
-        assert.equal('/path/to/theme/locales/en.default.json', file);
-        assert.equal("'hello_html' contains invalid HTML. See https://github.com/htmllint/htmllint/wiki/Options#tag-close", message);
-      });
-    });
+        assert.equal(1, this.reporter.failures.length)
+        const [message, file] = this.reporter.failures[0]
+        assert.equal('/path/to/theme/locales/en.default.json', file)
+        assert.equal("'hello_html' contains invalid HTML. See https://github.com/htmllint/htmllint/wiki/Options#tag-close", message)
+      })
+    })
 
-    it('reports a failure for invalid HTML in pluralized key', function() {
+    it('reports a failure for invalid HTML in pluralized key', function () {
       mockFs({
         '/path/to/theme': {
           'locales': {
@@ -231,14 +231,14 @@ describe('I18nLinter', function(){
             })
           }
         }
-      });
+      })
 
       return this.linter.testHTML(this.reporter).then(() => {
-        assert.equal(1, this.reporter.failures.length);
-        const [message, file] = this.reporter.failures[0];
-        assert.equal('/path/to/theme/locales/en.default.json', file);
-        assert.equal("'product_count_html.other' contains invalid HTML. See https://github.com/htmllint/htmllint/wiki/Options#tag-close", message);
-      });
-    });
-  });
-});
+        assert.equal(1, this.reporter.failures.length)
+        const [message, file] = this.reporter.failures[0]
+        assert.equal('/path/to/theme/locales/en.default.json', file)
+        assert.equal("'product_count_html.other' contains invalid HTML. See https://github.com/htmllint/htmllint/wiki/Options#tag-close", message)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Mostly getting rid of semi-colons in a non destructive way by using `standard --fix`

Also deleted the requiring of lodash in the cli.js file since its not being used at all and that may be prone to bugs in the future.