### PR TITLE
Update htmllint

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "glob": "^7.0.6",
-    "htmllint": "^0.6.0",
+    "htmllint": "^0.8.0",
     "lodash": "^4.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The 0.6 version of the htmllint library does not default to the correct version of `attr-name-style` which was fixed in 0.7 and above. See commit: https://github.com/htmllint/htmllint/commit/0d4dc0b938adbd919a7639f2e10da55f13240aa3

Ran the npm test:

```
18:07 /theme-lint/ (hotfix/update-htmllint) $ npm run test

> @shopify/theme-lint@2.0.0 test /Users/gilgreenberg/Projects/Shopify/theme-lint
> mocha ./test/**/*_test.js

  I18nLinter
    #testDefaultLocale
      ✓ reports a failure if the theme doesn't have a default locale
      ✓ reports a success if the theme has a default locale
    #testReferencedKeys
      ✓ reports a failure for keys in liquid that are missing from the default locale
      ✓ reports a failure for pluralized keys in liquid that are missing from the default locale
      ✓ reports a success for references that are present in the default locale
      ✓ reports a success for pluralized references that are present in the default locale
    #testMismatchedKeys
      ✓ reports a failure for keys present in the default locale but not others
      ✓ reports a failure for keys not present in the default locale but present in others
      ✓ reports a success if all keys match
    #testHTML
      ✓ reports a success for valid HTML
      ✓ reports a failure for invalid HTML
      ✓ reports a failure for invalid HTML in pluralized key


  12 passing (50ms)
```
