### PR TITLE
Bump mocha and mock-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lodash": "^4.15.0"
   },
   "devDependencies": {
-    "mocha": "^3.0.2",
-    "mock-fs": "^4.3.0",
+    "mocha": "^7.0.0",
+    "mock-fs": "^4.10.0",
     "prettier": "^1.8.1"
   },
   "directories": {


### PR DESCRIPTION
Title says it all. 

- The `mock-fs` bump is needed to get tests passing on recent versions of Node
- The `mocha` bump isn't strictly necessary but figured it would be a good time to update