### PR TITLE
add check for presence of pluralizations in locales other than the default locale

### DIFF
--- a/linters/i18n.js
+++ b/linters/i18n.js
@@ -9,7 +9,7 @@ const htmllint = require("htmllint");
 const Reporter = require("../reporter");
 const TranslationFilterScanner = require("./translation_filter_scanner");
 
-const PLURALIZATION_KEYS = ['zero', 'one', 'two', 'few', 'many', 'other'];
+const PLURALIZATION_KEYS = ["zero", "one", "two", "few", "many", "other"];
 
 // https://github.com/htmllint/htmllint/wiki/Options
 const HTML_LINT_RULES = {
@@ -76,7 +76,7 @@ module.exports = class I18nLinter {
       ([translations, defaultLocale]) => {
         const defaultLocaleData = translations[defaultLocale] || {};
         const defaultLocaleKeys = Object.keys(defaultLocaleData);
-        const regex = new RegExp(`\\.((${PLURALIZATION_KEYS.join('|')}){1})$`);
+        const regex = new RegExp(`\\.((${PLURALIZATION_KEYS.join("|")}){1})$`);
 
         _.forOwn(translations, (localeData, key) => {
           if (key === defaultLocale) return;
@@ -94,19 +94,21 @@ module.exports = class I18nLinter {
             );
           }
 
-          const extraKeys = _.difference(localeKeys, defaultLocaleKeys).filter(key => {
-            if(!key.match(regex)) return true;
+          const extraKeys = _.difference(localeKeys, defaultLocaleKeys).filter(
+            key => {
+              if (!key.match(regex)) return true;
 
-            const lastPart = key.match(regex);
-            const filteredKeys = PLURALIZATION_KEYS.filter(pluralKey => {
-              if (lastPart.includes(pluralKey)) return false;
+              const lastPart = key.match(regex);
+              const filteredKeys = PLURALIZATION_KEYS.filter(pluralKey => {
+                if (lastPart.includes(pluralKey)) return false;
 
-              const newKey = key.replace(lastPart[0], `.${pluralKey}`);
-              return localeData[newKey] !== undefined;
-            });
+                const newKey = key.replace(lastPart[0], `.${pluralKey}`);
+                return localeData[newKey] !== undefined;
+              });
 
-            return !filteredKeys.length;
-          });
+              return !filteredKeys.length;
+            }
+          );
 
           if (extraKeys.length > 0) {
             reporter.failure(

--- a/test/linters/i18n_test.js
+++ b/test/linters/i18n_test.js
@@ -202,31 +202,27 @@ describe("I18nLinter", function() {
       mockFs({
         "/path/to/theme": {
           locales: {
-            "en.default.json": JSON.stringify(
-              {
-                products: {
-                  product: {
-                    count: {
-                      one: "un",
-                      other: "autre"
-                    }
+            "en.default.json": JSON.stringify({
+              products: {
+                product: {
+                  count: {
+                    one: "un",
+                    other: "autre"
                   }
                 }
               }
-            ),
-            "fr.json": JSON.stringify(
-              {
-                products: {
-                  product: {
-                    count: {
-                      one: "un",
-                      many: "plusieurs",
-                      other: "autre"
-                    }
+            }),
+            "fr.json": JSON.stringify({
+              products: {
+                product: {
+                  count: {
+                    one: "un",
+                    many: "plusieurs",
+                    other: "autre"
                   }
                 }
               }
-            )
+            })
           }
         }
       });
@@ -246,33 +242,29 @@ describe("I18nLinter", function() {
       mockFs({
         "/path/to/theme": {
           locales: {
-            "en.default.json": JSON.stringify(
-              {
-                products: {
-                  product: {
-                    count: {
-                      one: "un",
-                      other: "autre"
-                    }
+            "en.default.json": JSON.stringify({
+              products: {
+                product: {
+                  count: {
+                    one: "un",
+                    other: "autre"
                   }
                 }
               }
-            ),
-            "fr.json": JSON.stringify(
-              {
-                products: {
-                  product: {
-                    count: {
-                      one: "un",
-                      many: "plusieurs",
-                      other: "autre",
-                      ten: "dix"
-                    },
-                    one: "Titre"
-                  }
+            }),
+            "fr.json": JSON.stringify({
+              products: {
+                product: {
+                  count: {
+                    one: "un",
+                    many: "plusieurs",
+                    other: "autre",
+                    ten: "dix"
+                  },
+                  one: "Titre"
                 }
               }
-            )
+            })
           }
         }
       });


### PR DESCRIPTION
### Purpose
This PR updates the translation tests for themes to include new pluralization keys (`few` and `many`) and to update the way we handle extra keys, specifically for pluralization keys. 

We’re updating the tests since they were incorrectly handling pluralization in languages that have different pluralization subkeys than English.

### Approach 
1. I've updated the tests to check if the `extraKeys` in the non-default locales are pluralizations, and if they are to ignore them - because some non-default locales _can have_ extra pluralization keys. 

**Default Locale**
```yml
products: {
  product: {
    count: {
        one: "one",
        other: "other"
    }
  }
}
```
**Non-default locale**

Pass (extra key that is a pluralization key): 
```yml
products: {
  product: {
    count: {
        one: "one",
        other: "other",
        many: "many"
    }
  }
}
```

Fail (extra key that is not a pluralization key):  
```yml
products: {
  product: {
    count: {
        one: "one",
        other: "other",
        ten: "ten"
    }
  }
}
```

2. If the extra key contains a pluralization key, but does not have any "sibling" keys that are also pluralization keys, then it's assumed that the key is not being used for pluralizations, and should be included in the `extraKeys` output - and the test should fail.

**Default Locale**
```yml
products: {
  product: {
      heading: "title"
  }
}
```
**Non-default locale**

Pass: 
```yml
products: {
  product: {
      heading: "titre"
  }
}
```

Fail: 
```yml
products: {
  product: {
    heading: "titre"
    one: "one"
}
```
### Question 
#### 1. Pluralization keys not used for pluralizations
For the second point, this could be an issue if someone uses two pluralization keys as "regular" translation keys, but doesn't intend for them to be used for pluralizations. That said, I think that would be rare, especially if the key is an "Extra key" in a non-default locale. Someone would have to add that translations manually, for something like that to happen (I think). 

**Default Locale**
```yml
products: {
  product: {
      heading: "title"
  }
}
```
**Non-default locale**

Pass (two pluralization keys, not being used as pluralization keys):
```yml
products: {
  product: {
      heading: "titre",
      one: "one",
      two: "two"
  }
}
```

Fail:  
```yml
products: {
  product: {
    heading: "titre",
    one: "one"
}
```

#### 2. Tests
Would appreciate feedback on tests, and whether they're appropriate, or if I should be adding more.